### PR TITLE
Remove ophyd_async.plan_stubs environment source

### DIFF
--- a/services/p49-blueapi/values.yaml
+++ b/services/p49-blueapi/values.yaml
@@ -38,8 +38,6 @@ blueapi:
         module: htss_rig_bluesky.plans
       - kind: planFunctions
         module: dodal.plans
-      - kind: planFunctions
-        module: ophyd_async.plan_stubs
       events:
         broadcast_status_events: False
     stomp:


### PR DESCRIPTION
Seeing whether this is what is stopping BlueAPI from initialising correctly