### PR TITLE
Update epics-gateways to match template v5.7.1

### DIFF
--- a/services/p49-epics-gateways/values.yaml
+++ b/services/p49-epics-gateways/values.yaml
@@ -1,5 +1,8 @@
 epics-gateways:
-  # switch to developer image for debugging
-  image: ghcr.io/epics-containers/epics-gateways-developer:2025.11.1
-  # needs to be a server in controls dev network
-  nodeName: bl49p-ea-serv-01.diamond.ac.uk
+  # developer image for debugging no longer needed - defaults to helm chart version
+  # image: ghcr.io/epics-containers/epics-gateways-developer:2026.3.18
+
+  # use ixxdetector account for your beamline
+  securityContext:
+    runAsUser: 37889
+    runAsGroup: 37889


### PR DESCRIPTION
(somehow it went through the net of the previous copier update)
This pull request updates the configuration for the `epics-gateways` service, mainly focusing on removing the developer image override and improving security by specifying the user and group for the container.

Configuration and deployment changes:

* Removed the explicit override for the `epics-gateways-developer` image, so the deployment now uses the default image specified by the Helm chart.
* Added a `securityContext` section to run the container as the `ixxdetector` user and group (UID and GID 37889), enhancing security and aligning with beamline account practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default container image configuration for the EPICS Gateways deployment.
  * Added runtime security settings to run the deployment with the designated user and group IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->