### PR TITLE
Use updated beta version of ioc-adaravis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 uv
-urllib3<2.4.0
+urllib3<2.7.1
 Kodman
 ibek==4.6.1
 techui-builder>=0.7.6

--- a/services/bl49p-ea-dcam-01/values.yaml
+++ b/services/bl49p-ea-dcam-01/values.yaml
@@ -1,4 +1,4 @@
 # yaml-language-server: $schema=https://github.com/epics-containers/ec-helm-charts/releases/download/5.5.0/ioc-instance.schema.json#/$defs/service
 
 ioc-instance:
-  image: ghcr.io/epics-containers/ioc-adaravis-runtime:2026.4.3
+  image: ghcr.io/epics-containers/ioc-adaravis-runtime:r2-3-ec1.beta.25

--- a/services/bl49p-ea-dcam-02/values.yaml
+++ b/services/bl49p-ea-dcam-02/values.yaml
@@ -1,4 +1,4 @@
 # yaml-language-server: $schema=https://github.com/epics-containers/ec-helm-charts/releases/download/5.5.0/ioc-instance.schema.json#/$defs/service
 
 ioc-instance:
-  image: ghcr.io/epics-containers/ioc-adaravis-runtime:2026.4.3
+  image: ghcr.io/epics-containers/ioc-adaravis-runtime:r2-3-ec1.beta.25


### PR DESCRIPTION
With service template v5.7.1, ioc-adaravis v2026.4.3 leads to a recurring ioc pod error related to 'makePvi.py' (file /tmp/${instance_id}-genicam.xml not found) despite the pod starting up cleanly.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application runtime components to a newer release across both data collection services.
  - Refreshed supporting platform packages to maintain compatibility with the updated runtime.
  - No user-facing features or configuration changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->